### PR TITLE
Espaço para divulgar projetos brasileiros

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Projetos Open-source
 
-Já possui um projeto ou conhece algum bem bacana feito pela comunidade brasileira? Não deixe de adicioná-lo a (nossa lista)[https://github.com/frontendbr/open-source/tree/master/projetos].
+Já possui um projeto ou conhece algum bem bacana feito pela comunidade brasileira? Não deixe de adicioná-lo a [nossa lista](https://github.com/frontendbr/open-source/tree/master/projetos).
 
 
 ## Peça ajuda para seu projeto

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 # Projetos Open-source
 
+Já possui um projeto ou conhece algum bem bacana feito pela comunidade brasileira? Não deixe de adicioná-lo a (nossa lista)[https://github.com/frontendbr/open-source/tree/master/projetos].
+
+
+## Peça ajuda para seu projeto
+
 Como vimos que na [issue](https://github.com/frontendbr/forum/issues/5) do [Fórum](https://github.com/frontendbr/forum/), temos vários projetos da comunidade que precisam de apoio para resolver algumas issues ou dar um gás no desenvolvimento, resolvemos adicionar esse repositório pra apoiar ou até mesmo criar novos projetos, conforme sugestões da própria comunidade.
  
 ## Como sugerir um projeto

--- a/projetos/readme.md
+++ b/projetos/readme.md
@@ -1,0 +1,15 @@
+# Projetos
+
+Se você possui algum projeto open-source, não deixe de inseri-lo nessa lista, assim outros desenvolvedores poderão usar ele e até mesmo contribuir com o projeto
+
+## Animações
+
+* [AnimusJS](https://github.com/soutomario/animusjs): A solução para gerenciar animações em scroll com JavaScript e CSS.
+
+## Boilerplates
+
+* [qualy-presenter](https://github.com/Qualy-org/qualy-presenter): A boilerplate to create presentations using Reveal.JS, Gulp, Stylus and more.
+
+## ...
+
+* [fdaciuk-ajax](https://github.com/fdaciuk/ajax): Ajax module in Vanilla JS

--- a/projetos/readme.md
+++ b/projetos/readme.md
@@ -20,4 +20,4 @@ Se você possui algum projeto open-source, não deixe de inseri-lo nessa lista, 
 ## Não categorizadas
 
 * [fdaciuk-ajax](https://github.com/fdaciuk/ajax): Ajax module in Vanilla JS
-* [cep-promisse](https://github.com/filipedeschamps/cep-promise): Busca por CEP integrado diretamente aos serviços dos Correios e ViaCEP (Node.js e Browser)
+* [cep-promise](https://github.com/filipedeschamps/cep-promise): Busca por CEP integrado diretamente aos serviços dos Correios e ViaCEP (Node.js e Browser)

--- a/projetos/readme.md
+++ b/projetos/readme.md
@@ -9,7 +9,15 @@ Se você possui algum projeto open-source, não deixe de inseri-lo nessa lista, 
 ## Boilerplates
 
 * [qualy-presenter](https://github.com/Qualy-org/qualy-presenter): A boilerplate to create presentations using Reveal.JS, Gulp, Stylus and more.
+* [__s](https://github.com/woliveiras/__s): __s, or dunders, is a simple Jekyll Starter Theme
 
-## ...
+## Componentes
+
+* [CSS Components](https://github.com/LFeh/css-components): A set of common UI Components using the power of CSS and without Javascript. 
+* [iziModal](https://github.com/dolce/iziModal): Elegant, responsive, flexible and lightweight modal plugin with jQuery.
+* [iziToast](https://github.com/dolce/iziToast): Elegant, responsive, flexible and lightweight notification plugin with no dependencies.
+
+## Não categorizadas
 
 * [fdaciuk-ajax](https://github.com/fdaciuk/ajax): Ajax module in Vanilla JS
+* [cep-promisse](https://github.com/filipedeschamps/cep-promise): Busca por CEP integrado diretamente aos serviços dos Correios e ViaCEP (Node.js e Browser)


### PR DESCRIPTION
Estou adicionando uma área para podermos cadastrar projetos open-source da comunidade brasileira, acho uma proposta interessante visto que muitos projetos bons são criados e acabam sendo perdidos em meio aos feeds das comunidades no facebook.